### PR TITLE
Fix formatting of speech_categories in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Clipper is a Python-based tool designed to extract video clips from `.mp4` files
        "max_workers": 2,
        "use_subdirs": false,
        "logging": "INFO",
-       "speech_categories": [ ],
+       "speech_categories": [ ]
      }
      ```
 


### PR DESCRIPTION
When a new user just copy the example config it give an error because of the comma at the end